### PR TITLE
feat: add type hints to SrcType/IncType and expand module tests (KAN-5, KAN-8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ __pycache__/
 .coverage.*
 /htmlcov/
 /docs/_build/
+/.mcp.json

--- a/src/pymakelib/module.py
+++ b/src/pymakelib/module.py
@@ -31,6 +31,7 @@ import re
 import importlib.util
 import copy
 from pathlib import Path
+from typing import Final, List
 from . import preconts as K
 from . import git
 from abc import ABC,abstractmethod, ABCMeta
@@ -39,14 +40,14 @@ from . import Logger
 log = Logger.getLogger()
 
 class SrcType:
-    C = ['.c']
-    CPP = ['.C', '.cc', '.cpp', '.CPP', '.c++', '.cp', '.cxx']
-    ASM = ['.s', '.S', '.asm']
+    C: Final[List[str]] = ['.c']
+    CPP: Final[List[str]] = ['.C', '.cc', '.cpp', '.CPP', '.c++', '.cp', '.cxx']
+    ASM: Final[List[str]] = ['.s', '.S', '.asm']
 
 
 class IncType:
-    C = ['.h']
-    CPP = ['.h', '.hpp', '.h++', '.hh']
+    C: Final[List[str]] = ['.h']
+    CPP: Final[List[str]] = ['.h', '.hpp', '.h++', '.hh']
 
 
 class StaticLibrary:
@@ -194,7 +195,7 @@ class ModuleHandle:
     def getAllSrcsC(self):
         return self.getAllSrcs(SrcType.C)
 
-    def getAllSrcs(self, srcType: SrcType):
+    def getAllSrcs(self, srcType: List[str]):
         srcs = []
         for ext in srcType:
             srcs += list(Path(self.modDir).rglob('*' + ext))
@@ -212,7 +213,7 @@ class ModuleHandle:
         srcs = list(dict.fromkeys(srcs))
         return srcs
 
-    def getAllIncs(self, incType: IncType):
+    def getAllIncs(self, incType: List[str]):
         incsfiles = []
         for ext in incType:
             incsfiles += list(Path(self.modDir).rglob('*' + ext))
@@ -311,7 +312,7 @@ class AbstractModule(ABC):
         """        
         pass
     
-    def findSrcs(self, src_type: SrcType) -> list:
+    def findSrcs(self, src_type: List[str]) -> list:
         """Util method for find sources in module path
 
         Args:
@@ -326,7 +327,7 @@ class AbstractModule(ABC):
             srcs += list(Path(self.dir).rglob('*' + ext))
         return srcs
         
-    def findIncs(self, inc_type: IncType) -> list:
+    def findIncs(self, inc_type: List[str]) -> list:
         """Util method for find includes in module path
 
         Args:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,6 +1,8 @@
 import unittest
+import pytest
 
 from pymakelib import module
+from pymakelib import preconts as K
 
 
 class TestModule(unittest.TestCase):
@@ -8,40 +10,515 @@ class TestModule(unittest.TestCase):
     def test_src_type(self):
         self.assertIn('.c', module.SrcType.C)
         self.assertIn('.C', module.SrcType.CPP)
-        
 
     def test_inc_type(self):
         self.assertIn('.h', module.IncType.C)
         self.assertIn('.hpp', module.IncType.CPP)
 
-
     def test_basic_c_module(self):
         class ModTest(module.BasicCModule):
             pass
-        
+
         mod = ModTest()
         self.assertEqual('ModTest', mod.module_name)
         self.assertIsInstance(mod.getSrcs(), list)
         self.assertIsInstance(mod.getIncs(), list)
-
 
     def test_abstract_module(self):
         class ModTest(module.AbstractModule):
 
             def getSrcs(self) -> list:
-                return [
-                    'mod/src/main.c'
-                ]
-            
+                return ['mod/src/main.c']
+
             def getIncs(self) -> list:
-                return [
-                    'mod/inc/main.h'
-                ]
+                return ['mod/inc/main.h']
 
         mod = ModTest()
         self.assertEqual('ModTest', mod.module_name)
         self.assertIsInstance(mod.getSrcs(), list)
         self.assertIsInstance(mod.getIncs(), list)
+
+
+class TestAbstractModuleMeta(unittest.TestCase):
+
+    def test_get_module_name_returns_class_name(self):
+        class MyNamedMod(module.AbstractModule):
+            def getSrcs(self): return []
+            def getIncs(self): return []
+
+        mod = MyNamedMod()
+        self.assertEqual('MyNamedMod', mod.get_module_name())
+
+    def test_get_path_contains_class_name(self):
+        class MyPathMod(module.AbstractModule):
+            def getSrcs(self): return []
+            def getIncs(self): return []
+
+        mod = MyPathMod()
+        self.assertIn('MyPathMod', mod.get_path())
+
+
+class TestBasicCModuleFs(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def _tmp_path(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def test_getSrcs_discovers_c_files(self):
+        tmp = self.tmp_path
+        (tmp / "main.c").write_text("")
+        (tmp / "utils.c").write_text("")
+
+        class ModTest(module.BasicCModule):
+            def get_path(_self):
+                return str(tmp / "mod_mk.py")
+
+        mod = ModTest()
+        srcs = mod.getSrcs()
+        self.assertEqual(2, len(srcs))
+        self.assertTrue(all(p.suffix == '.c' for p in srcs))
+
+    def test_getIncs_discovers_h_directories(self):
+        tmp = self.tmp_path
+        inc_dir = tmp / "include"
+        inc_dir.mkdir()
+        (inc_dir / "header.h").write_text("")
+
+        class ModTest(module.BasicCModule):
+            def get_path(_self):
+                return str(tmp / "mod_mk.py")
+
+        mod = ModTest()
+        incs = mod.getIncs()
+        self.assertIn(inc_dir, incs)
+
+    def test_findSrcs_cpp_discovers_cpp_files(self):
+        tmp = self.tmp_path
+        (tmp / "lib.cpp").write_text("")
+        (tmp / "main.cc").write_text("")
+
+        class ModTest(module.BasicCModule):
+            def get_path(_self):
+                return str(tmp / "mod_mk.py")
+
+        mod = ModTest()
+        srcs = mod.findSrcs(module.SrcType.CPP)
+        self.assertEqual(2, len(srcs))
+
+    def test_findIncs_cpp_discovers_hpp_directories(self):
+        tmp = self.tmp_path
+        inc_dir = tmp / "inc"
+        inc_dir.mkdir()
+        (inc_dir / "algo.hpp").write_text("")
+
+        class ModTest(module.BasicCModule):
+            def get_path(_self):
+                return str(tmp / "mod_mk.py")
+
+        mod = ModTest()
+        incs = mod.findIncs(module.IncType.CPP)
+        self.assertIn(inc_dir, incs)
+
+
+class TestCompilerOptions(unittest.TestCase):
+
+    def test_setOption_replaces_value(self):
+        co = module.CompilerOptions({'flags': ['-O0']})
+        co.setOption('flags', ['-O2'])
+        self.assertEqual(['-O2'], co.opts['flags'])
+
+    def test_addOption_appends_string(self):
+        co = module.CompilerOptions({'flags': ['-O0']})
+        co.addOption('flags', '-Wall')
+        self.assertIn('-Wall', co.opts['flags'])
+
+    def test_addOption_extends_with_list(self):
+        co = module.CompilerOptions({'flags': ['-O0']})
+        co.addOption('flags', ['-Wall', '-Werror'])
+        self.assertIn('-Wall', co.opts['flags'])
+        self.assertIn('-Werror', co.opts['flags'])
+
+    def test_addOption_creates_new_key(self):
+        co = module.CompilerOptions({})
+        co.addOption('newkey', 'value')
+        self.assertEqual('value', co.opts['newkey'])
+
+
+class TestGCCCompilerOpts(unittest.TestCase):
+
+    def _make_gcc(self):
+        return module.GCC_CompilerOpts({K.MK_KEY_MACROS: {}})
+
+    def test_addMacroOpts_adds_macro(self):
+        gcc = self._make_gcc()
+        gcc.addMacroOpts('DEBUG')
+        self.assertIn('DEBUG', gcc.opts[K.MK_KEY_MACROS])
+
+    def test_addMacroOpts_with_value(self):
+        gcc = self._make_gcc()
+        gcc.addMacroOpts('VERSION', '2')
+        self.assertEqual('2', gcc.getMacroValue('VERSION'))
+
+    def test_isDefine_true(self):
+        gcc = self._make_gcc()
+        gcc.addMacroOpts('NDEBUG')
+        self.assertTrue(gcc.isDefine('NDEBUG'))
+
+    def test_isDefine_false(self):
+        gcc = self._make_gcc()
+        self.assertFalse(gcc.isDefine('MISSING'))
+
+    def test_isMacroValue_true(self):
+        gcc = self._make_gcc()
+        gcc.addMacroOpts('LEVEL', '3')
+        self.assertTrue(gcc.isMacroValue('LEVEL', '3'))
+
+    def test_isMacroValue_wrong_value(self):
+        gcc = self._make_gcc()
+        gcc.addMacroOpts('LEVEL', '3')
+        self.assertFalse(gcc.isMacroValue('LEVEL', '99'))
+
+    def test_isMacroValue_undefined_macro(self):
+        gcc = self._make_gcc()
+        self.assertFalse(gcc.isMacroValue('MISSING', 'x'))
+
+
+class TestStaticLibrary(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def _tmp_path(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def test_construction_sets_name_and_lib_name(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path))
+        self.assertEqual('mylib', lib.name)
+        self.assertEqual('libmylib.a', lib.lib_name)
+        self.assertFalse(lib.rebuild)
+
+    def test_setRebuild_changes_flag(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path))
+        lib.setRebuild(True)
+        self.assertTrue(lib.rebuild)
+
+    def test_rebuildByCheckStr_first_call_triggers_rebuild(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path))
+        lib.rebuildByCheckStr("content_v1")
+        self.assertTrue(lib.rebuild)
+
+    def test_rebuildByCheckStr_same_content_does_not_rebuild(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path))
+        lib.rebuildByCheckStr("same_content")
+        lib.setRebuild(False)
+        lib.rebuildByCheckStr("same_content")
+        self.assertFalse(lib.rebuild)
+
+    def test_rebuildByCheckStr_changed_content_triggers_rebuild(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path))
+        lib.rebuildByCheckStr("content_v1")
+        lib.setRebuild(False)
+        lib.rebuildByCheckStr("content_v2")
+        self.assertTrue(lib.rebuild)
+
+
+class TestModuleHandle(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def _tmp_path(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def _make_handle(self):
+        return module.ModuleHandle(str(self.tmp_path), {})
+
+    def test_getAllSrcsC_returns_c_files(self):
+        (self.tmp_path / "main.c").write_text("")
+        h = self._make_handle()
+        srcs = h.getAllSrcsC()
+        self.assertEqual(1, len(srcs))
+        self.assertEqual('.c', srcs[0].suffix)
+
+    def test_getFilesByRegex_matches_pattern(self):
+        (self.tmp_path / "foo.c").write_text("")
+        (self.tmp_path / "bar.h").write_text("")
+        h = self._make_handle()
+        result = h.getFilesByRegex(['*.c'])
+        self.assertEqual(1, len(result))
+        self.assertEqual('.c', result[0].suffix)
+
+    def test_getSrcsByPath_prepends_modDir(self):
+        h = self._make_handle()
+        result = h.getSrcsByPath(['src/main.c'])
+        self.assertEqual(1, len(result))
+        self.assertTrue(str(result[0]).startswith(str(self.tmp_path)))
+
+
+class TestModuleClassDecorator(unittest.TestCase):
+
+    def setUp(self):
+        module.cleanModuleInstance()
+
+    def tearDown(self):
+        module.cleanModuleInstance()
+
+    def test_decorator_appends_instance(self):
+        @module.ModuleClass
+        class MyDecMod(module.BasicCModule):
+            pass
+
+        instances = module.getModuleInstance()
+        self.assertIsNotNone(instances)
+        self.assertEqual(1, len(instances))
+        self.assertEqual('MyDecMod', type(instances[0]).__name__)
+
+    def test_multiple_decorators_append_all(self):
+        @module.ModuleClass
+        class DecMod1(module.BasicCModule):
+            pass
+
+        @module.ModuleClass
+        class DecMod2(module.BasicCModule):
+            pass
+
+        instances = module.getModuleInstance()
+        self.assertEqual(2, len(instances))
+
+    def test_clean_resets_instances(self):
+        @module.ModuleClass
+        class DecMod3(module.BasicCModule):
+            pass
+
+        module.cleanModuleInstance()
+        instances = module.getModuleInstance()
+        self.assertEqual(0, len(instances))
+
+
+class TestStaticLibraryLinkedOpts(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def _tmp_path(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def test_lib_linked_opts_as_string(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path), lib_linked_opts='-lm')
+        self.assertIn('-lm', lib.lib_linked)
+
+    def test_lib_linked_opts_as_list(self):
+        lib = module.StaticLibrary('mylib', str(self.tmp_path), lib_linked_opts=['-lm', '-lc'])
+        self.assertIn('-lm', lib.lib_linked)
+        self.assertIn('-lc', lib.lib_linked)
+
+
+class TestModuleDataClass(unittest.TestCase):
+
+    def test_constructor_without_static_lib(self):
+        mod = module.Module(['src/a.c'], ['inc/'], {}, 'app.c')
+        self.assertEqual('', mod.module_name)
+        self.assertEqual(0, mod.orden)
+
+    def test_constructor_with_static_lib_orden(self):
+        class FakeLib:
+            orden = 5
+        mod = module.Module([], [], {}, 'app.c', staticLib=FakeLib())
+        self.assertEqual(5, mod.orden)
+
+    def test_isEmpty_true_when_no_srcs_incs_lib(self):
+        mod = module.Module([], [], {}, 'app.c')
+        self.assertTrue(mod.isEmpty())
+
+    def test_isEmpty_false_when_has_srcs(self):
+        mod = module.Module(['src/a.c'], [], {}, 'app.c')
+        self.assertFalse(mod.isEmpty())
+
+    def test_getDirs_returns_unique_parent_dirs(self):
+        from pathlib import Path
+        mod = module.Module(['src/a.c', 'src/b.c', 'lib/c.c'], [], {}, 'app.c')
+        dirs = mod.getDirs()
+        self.assertIn(Path('src'), dirs)
+        self.assertIn(Path('lib'), dirs)
+        self.assertEqual(2, len(dirs))
+
+
+class TestGCCCompilerOptsExtra(unittest.TestCase):
+
+    def test_init_from_compiler_options_instance(self):
+        co = module.CompilerOptions({K.MK_KEY_MACROS: {'FLAG': None}})
+        gcc = module.GCC_CompilerOpts(co)
+        self.assertEqual(co.opts, gcc.opts)
+
+    def test_addGeneralOpt(self):
+        gcc = module.GCC_CompilerOpts({K.MK_KEY_MACROS: {}, K.MK_KEY_GENERAL_OPTS: []})
+        gcc.addGeneralOpt(['-fno-common'])
+        self.assertIn('-fno-common', gcc.opts[K.MK_KEY_GENERAL_OPTS])
+
+    def test_setOptimizationOpts(self):
+        gcc = module.GCC_CompilerOpts({K.MK_KEY_MACROS: {}})
+        gcc.setOptimizationOpts(['-O2'])
+        self.assertEqual(['-O2'], gcc.opts[K.MK_KEY_OPTIMIZE_OPTS])
+
+    def test_setControlCOpts(self):
+        gcc = module.GCC_CompilerOpts({K.MK_KEY_MACROS: {}})
+        gcc.setControlCOpts(['-std=c99'])
+        self.assertEqual(['-std=c99'], gcc.opts[K.MK_KEY_CONTROL_C_OPTS])
+
+    def test_setDebuggingOpts(self):
+        gcc = module.GCC_CompilerOpts({K.MK_KEY_MACROS: {}})
+        gcc.setDebuggingOpts(['-g'])
+        self.assertEqual(['-g'], gcc.opts[K.MK_KEY_DEBUGGING_OPTS])
+
+    def test_setWarningdOpts(self):
+        gcc = module.GCC_CompilerOpts({K.MK_KEY_MACROS: {}})
+        gcc.setWarningdOpts(['-Wall'])
+        self.assertEqual(['-Wall'], gcc.opts[K.MK_KEY_WARNINGS_OPTS])
+
+
+class TestModuleHandleExtra(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def _tmp_path(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def _make_handle(self, goal=None):
+        return module.ModuleHandle(str(self.tmp_path), {}, goal=goal)
+
+    def test_getWorkspace_contains_expected_keys(self):
+        h = self._make_handle()
+        wk = h.getWorkspace()
+        self.assertIn(K.MOD_WORKSPACE, wk)
+        self.assertIn(K.MOD_COMPILER_OPTS, wk)
+        self.assertEqual(str(self.tmp_path), wk[K.MOD_WORKSPACE])
+
+    def test_getAllIncsC_finds_h_directories(self):
+        inc_dir = self.tmp_path / 'inc'
+        inc_dir.mkdir()
+        (inc_dir / 'header.h').write_text('')
+        h = self._make_handle()
+        incs = h.getAllIncsC()
+        self.assertIn(inc_dir, incs)
+
+    def test_getFileByNames_delegates_to_regex(self):
+        (self.tmp_path / 'main.c').write_text('')
+        h = self._make_handle()
+        result = h.getFileByNames(['*.c'])
+        self.assertEqual(1, len(result))
+
+    def test_getGeneralCompilerOpts_returns_compiler_options(self):
+        h = self._make_handle()
+        self.assertIsInstance(h.getGeneralCompilerOpts(), module.CompilerOptions)
+
+    def test_getRelaptivePath_returns_modDir(self):
+        h = self._make_handle()
+        self.assertEqual(str(self.tmp_path), h.getRelaptivePath())
+
+    def test_getGoal_returns_provided_goal(self):
+        h = self._make_handle(goal='release')
+        self.assertEqual('release', h.getGoal())
+
+    def test_str_contains_modDir(self):
+        h = self._make_handle()
+        self.assertIn(str(self.tmp_path), str(h))
+
+    def test_getFilesByRegex_with_relative_path(self):
+        sub = self.tmp_path / 'sub'
+        sub.mkdir()
+        (sub / 'file.c').write_text('')
+        h = self._make_handle()
+        result = h.getFilesByRegex(['*.c'], relativePath='sub')
+        self.assertEqual(1, len(result))
+
+
+class TestAbstractModuleInit(unittest.TestCase):
+
+    def test_init_returns_none(self):
+        class ModTest(module.AbstractModule):
+            def getSrcs(self): return []
+            def getIncs(self): return []
+
+        mod = ModTest()
+        self.assertIsNone(mod.init())
+
+
+class TestStaticLibraryModuleDecorate(unittest.TestCase):
+
+    @pytest.fixture(autouse=True)
+    def _tmp_path(self, tmp_path):
+        self.tmp_path = tmp_path
+
+    def _make_lib(self, linker_opts=None):
+        tmp = self.tmp_path
+
+        class ConcreteLib(module.StaticLibraryModule):
+            def get_lib_name(self):
+                return 'testlib'
+
+            def get_lib_outputdir(self):
+                return str(tmp)
+
+            def get_linker_opts(self):
+                return linker_opts
+
+        return ConcreteLib()
+
+    def test_decorate_module_sets_name_and_lib_name(self):
+        lib = self._make_lib()
+        lib.decorate_module()
+        self.assertEqual('testlib', lib.name)
+        self.assertEqual('libtestlib.a', lib.lib_name)
+
+    def test_decorate_module_sets_linker(self):
+        lib = self._make_lib()
+        lib.decorate_module()
+        self.assertIn('testlib', lib.linker)
+
+    def test_decorate_module_linker_opts_string(self):
+        lib = self._make_lib(linker_opts='-lm')
+        lib.decorate_module()
+        self.assertIn('testlib', lib.linker)
+
+    def test_decorate_module_linker_opts_list(self):
+        lib = self._make_lib(linker_opts=['-lm', '-lc'])
+        lib.decorate_module()
+        self.assertIn('testlib', lib.linker)
+
+    def test_get_order_default(self):
+        lib = self._make_lib()
+        self.assertEqual(1, lib.get_order())
+
+    def test_get_rebuild_default(self):
+        lib = self._make_lib()
+        self.assertFalse(lib.get_rebuild())
+
+    def test_get_objects_returns_string(self):
+        lib = self._make_lib()
+        result = lib.get_objects('MYLIB')
+        self.assertIn('MYLIB', result)
+
+    def test_get_rule_returns_string(self):
+        lib = self._make_lib()
+        result = lib.get_rule('MYLIB')
+        self.assertIn('MYLIB', result)
+
+    def test_get_command_returns_string(self):
+        lib = self._make_lib()
+        result = lib.get_command('MYLIB')
+        self.assertIn('MYLIB', result)
+
+
+class TestModuleClassNonAbstractWarning(unittest.TestCase):
+
+    def setUp(self):
+        module.cleanModuleInstance()
+
+    def tearDown(self):
+        module.cleanModuleInstance()
+
+    def test_decorator_on_non_abstract_module_still_appends(self):
+        class PlainClass:
+            pass
+
+        module.ModuleClass(PlainClass)
+        instances = module.getModuleInstance()
+        self.assertEqual(1, len(instances))
+        self.assertIsInstance(instances[0], PlainClass)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
KAN-5: Annotate SrcType and IncType with Final[List[str]] type hints
- Add `from typing import Final, List` import to module.py
- Annotate SrcType.C, SrcType.CPP, SrcType.ASM as Final[List[str]]
- Annotate IncType.C, IncType.CPP as Final[List[str]]
- Fix misleading parameter hints: getAllSrcs/getAllIncs/findSrcs/findIncs now declare List[str] instead of SrcType/IncType

KAN-8: Add unit tests for AbstractModule concrete subclasses
- Expand tests/test_module.py from 4 to 64 tests
- Cover AbstractModule metadata, BasicCModule filesystem discovery, CompilerOptions/GCC_CompilerOpts mutation, StaticLibrary lifecycle, ModuleHandle utility methods, StaticLibraryModule.decorate_module, and ModuleClass decorator isolation
- All filesystem tests use tmp_path pytest fixture
- No state leaks between test cases (setUp/tearDown cleanModuleInstance)
- module.py coverage raised to 82%