### PR TITLE
feat(moduleignore): rewrite with gitignore-style pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,88 @@ class App(module.BasicCModule):
 
 ---
 
+## Ignoring Modules During Discovery
+
+**pymaketool** automatically reads `.gitignore` by default and applies gitignore-style pattern matching to skip module files during discovery. You can also use `.moduleignore` for pymaketool-specific ignore patterns.
+
+### Quick start
+
+Create a `.moduleignore` file in `pymake/` (or project root as fallback):
+
+```gitignore
+# Ignore test modules
+tests/
+*_test_mk.py
+
+# Ignore vendor code
+vendor/
+third_party/
+
+# Ignore specific modules
+experimental/prototype_mk.py
+```
+
+### Pattern syntax
+
+`.moduleignore` and `.gitignore` use **gitignore-style patterns**:
+
+| Pattern | Matches |
+|---------|---------|
+| `test_*.py` | Any file starting with `test_` |
+| `build/` | Entire `build/` directory and its contents |
+| `**/temp_*` | `temp_*` files at any depth |
+| `*.tmp` | Any file ending with `.tmp` |
+| `!important_mk.py` | Negation: exclude `important_mk.py` from ignore |
+
+Comments (`#`) and blank lines are ignored.
+
+### Source precedence
+
+Ignore patterns are merged from multiple sources in this order:
+
+1. **`.gitignore`** (project root) — read by default
+2. **`.moduleignore`** (`pymake/.moduleignore` preferred, fallback to root `.moduleignore`)
+3. **`Makefile.py`** — additional patterns via `ignore_list`
+
+Later sources can override earlier ones using negation (`!pattern`).
+
+### Control via Makefile.py
+
+Disable `.gitignore` or add extra patterns:
+
+```python
+from pymakelib import ProjectConfig, Makeclass
+
+@Makeclass
+class Build(ProjectConfig):
+    use_gitignore = False               # disable .gitignore reading
+    ignore_list   = ['vendor/', 'tmp/'] # additional patterns
+    ...
+```
+
+Or override the `getIgnoreConfig()` method for dynamic control:
+
+```python
+@Makeclass
+class Build(ProjectConfig):
+    ...
+    
+    def getIgnoreConfig(self):
+        return {
+            'use_gitignore': True,
+            'ignore_list': ['tests/', 'experimental/']
+        }
+```
+
+### File location
+
+- **Preferred**: `pymake/.moduleignore` (alongside `Makefile.py`)
+- **Fallback**: `.moduleignore` in project root (for legacy projects)
+
+**Why `.gitignore` by default?** Most projects already ignore build artifacts, vendor code, and tests in `.gitignore`. Reading it by default reduces duplication and follows the principle of least surprise.
+
+---
+
 ## Project Configuration (`Makefile.py`)
 
 `Makefile.py` is the project entry point. It defines the toolchain, compiler flags, and build targets.

--- a/src/pymakelib/__init__.py
+++ b/src/pymakelib/__init__.py
@@ -310,6 +310,22 @@ class AbstractMake(ABC):
 
     def getPhonyTargets(self) -> dict[str, PhonyTarget]:
         return {}
+    
+    def getIgnoreConfig(self) -> dict:
+        """Return ignore configuration for module discovery.
+        
+        Override to customize ignore behavior. Returns dict with keys:
+        - 'use_gitignore': bool (default True) - whether to read .gitignore
+        - 'ignore_list': List[str] (default []) - additional patterns to ignore
+        
+        Example:
+            def getIgnoreConfig(self):
+                return {
+                    'use_gitignore': True,
+                    'ignore_list': ['tests/', 'vendor/']
+                }
+        """
+        return {}
 
 
 class ProjectConfig(AbstractMake):
@@ -348,12 +364,16 @@ class ProjectConfig(AbstractMake):
         compiler_set: toolchain — set to get_gcc_linux() etc. (REQUIRED)
         addons:       list of addon classes, e.g. [EclipseAddon, VSCodeAddon]
         env_file:     optional path to a .env file loaded before build config
+        use_gitignore: whether to read .gitignore for module discovery (default True)
+        ignore_list:  additional patterns to ignore during module discovery (default [])
     """
-    name:         str              = ''
-    output_dir:   str              = 'build/obj/'
-    compiler_set: Optional[object] = None
-    addons:       List[type]       = field(default_factory=list) if False else []
-    env_file:     Optional[str]    = None
+    name:          str              = ''
+    output_dir:    str              = 'build/obj/'
+    compiler_set:  Optional[object] = None
+    addons:        List[type]       = field(default_factory=list) if False else []
+    env_file:      Optional[str]    = None
+    use_gitignore: bool             = True
+    ignore_list:   List[str]        = field(default_factory=list) if False else []
 
     def getProjectSettings(self, **kwargs) -> dict:
         n = self.name or os.path.basename(os.getcwd())
@@ -395,6 +415,13 @@ class ProjectConfig(AbstractMake):
             if isinstance(first_val, Target):
                 return {name: t.to_dict() for name, t in result.items()}
         return result
+    
+    def getIgnoreConfig(self) -> dict:
+        """Return ignore configuration from attributes or override method."""
+        return {
+            'use_gitignore': self.use_gitignore,
+            'ignore_list': self.ignore_list,
+        }
 
 
 def Makeclass(clazz):

--- a/src/pymakelib/module.py
+++ b/src/pymakelib/module.py
@@ -285,7 +285,11 @@ class AbstractModule(ABC):
         self.dir = Path(self.path).parent
         _mod = sys.modules.get(self.__module__)
         _proj_root = getattr(_mod, '_project_root', None) if _mod is not None else None
-        _src_file = Path(self.path).resolve()
+        # Use the logical (non-symlink-resolved) path so that modules inside
+        # symlinked directories (e.g. TARGET/ → foreign project sources) remain
+        # relative to the workspace root instead of their real filesystem location.
+        _src_file_logical = Path(self.path).absolute()
+        _src_file = _src_file_logical
         if _proj_root is None:
             # Class defined in a helper module (e.g. pym.py via module()).
             # Fall back: find a dynamically-loaded mk.py module in sys.modules whose

--- a/src/pymakelib/moduleignore.py
+++ b/src/pymakelib/moduleignore.py
@@ -1,32 +1,218 @@
-from pathlib import Path
-from . import preconts
+"""Module discovery ignore management with gitignore-style semantics.
 
-def readIgnoreFile(file = Path(preconts.MODULEIGNORE_FILE)):
+Supports:
+- Reading .gitignore by default
+- Reading .moduleignore (pymake/.moduleignore preferred, fallback to root)
+- Makefile.py control options (use_gitignore, ignore_list)
+- Full gitwildmatch pattern syntax via pathspec
+"""
+
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+import pathspec
+from . import preconts
+from . import Logger
+
+log = Logger.getLogger()
+
+
+class IgnoreSpec:
+    """Compiled ignore pattern matcher using gitignore semantics."""
+    
+    def __init__(self, spec: pathspec.PathSpec):
+        self._spec = spec
+    
+    def match_file(self, path: str) -> bool:
+        """Check if a path should be ignored.
+        
+        Args:
+            path: Project-relative POSIX-style path (e.g., 'app/mk.py')
+        
+        Returns:
+            True if the path matches any ignore pattern
+        """
+        return self._spec.match_file(path)
+    
+    def __bool__(self):
+        """Return False if no patterns (allows `if ignore_spec:` checks)."""
+        return bool(self._spec.patterns)
+
+
+def _normalize_path(path: Path, project_root: Path) -> str:
+    """Normalize a path to project-relative POSIX style.
+    
+    Args:
+        path: Absolute or relative path
+        project_root: Project root directory
+    
+    Returns:
+        Project-relative path with forward slashes
+    """
+    try:
+        if path.is_absolute():
+            rel_path = path.relative_to(project_root)
+        else:
+            rel_path = path
+        # Convert to POSIX style (forward slashes)
+        return str(rel_path).replace('\\', '/')
+    except (ValueError, OSError):
+        # Path is outside project root or invalid
+        log.debug(f"Path {path} could not be normalized relative to {project_root}")
+        return str(path).replace('\\', '/')
+
+
+def _read_patterns_from_file(file_path: Path) -> List[str]:
+    """Read ignore patterns from a file, filtering comments and blank lines.
+    
+    Args:
+        file_path: Path to ignore file
+    
+    Returns:
+        List of pattern strings (non-empty, non-comment lines)
+    """
+    patterns = []
+    if not file_path.exists():
+        return patterns
+    
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.rstrip('\n\r')
+                # Skip blank lines and comments
+                if line and not line.lstrip().startswith('#'):
+                    patterns.append(line)
+        log.debug(f"Loaded {len(patterns)} patterns from {file_path}")
+    except Exception as e:
+        log.debug(f"Could not read ignore file {file_path}: {e}")
+    
+    return patterns
+
+
+def _resolve_ignore_file_paths(
+    project_root: Path,
+    config_dir: Optional[Path] = None
+) -> tuple[Optional[Path], Optional[Path]]:
+    """Resolve paths to .moduleignore and .gitignore files.
+    
+    Args:
+        project_root: Project root directory
+        config_dir: Config directory (pymake/ or project root)
+    
+    Returns:
+        Tuple of (moduleignore_path, gitignore_path), either can be None
+    """
+    # .moduleignore: prefer config_dir (pymake/), fallback to root
+    moduleignore_path = None
+    if config_dir and (config_dir / preconts.MODULEIGNORE_FILE).exists():
+        moduleignore_path = config_dir / preconts.MODULEIGNORE_FILE
+    elif (project_root / preconts.MODULEIGNORE_FILE).exists():
+        moduleignore_path = project_root / preconts.MODULEIGNORE_FILE
+    
+    # .gitignore: always at project root
+    gitignore_path = project_root / '.gitignore'
+    if not gitignore_path.exists():
+        gitignore_path = None
+    
+    return moduleignore_path, gitignore_path
+
+
+def read_ignore_spec(
+    project_root: Path,
+    config_dir: Optional[Path] = None,
+    makefile_config: Optional[Dict[str, Any]] = None
+) -> IgnoreSpec:
+    """Read and compile ignore patterns from all sources.
+    
+    Merge order (later sources can override with negation):
+    1. .gitignore (if use_gitignore not disabled)
+    2. .moduleignore (pymake/.moduleignore or root .moduleignore)
+    3. Makefile.py ignore_list (if provided)
+    
+    Args:
+        project_root: Project root directory
+        config_dir: Config directory (pymake/ or project root)
+        makefile_config: Optional config from Makefile.py with keys:
+            - 'use_gitignore': bool (default True)
+            - 'ignore_list': List[str] (additional patterns)
+    
+    Returns:
+        Compiled IgnoreSpec matcher
+    """
+    if makefile_config is None:
+        makefile_config = {}
+    
+    use_gitignore = makefile_config.get('use_gitignore', True)
+    extra_patterns = makefile_config.get('ignore_list', [])
+    
+    all_patterns = []
+    
+    moduleignore_path, gitignore_path = _resolve_ignore_file_paths(
+        project_root, config_dir
+    )
+    
+    # 1. Load .gitignore if enabled
+    if use_gitignore and gitignore_path:
+        patterns = _read_patterns_from_file(gitignore_path)
+        all_patterns.extend(patterns)
+        log.debug(f"Loaded {len(patterns)} patterns from .gitignore")
+    
+    # 2. Load .moduleignore
+    if moduleignore_path:
+        patterns = _read_patterns_from_file(moduleignore_path)
+        all_patterns.extend(patterns)
+        log.debug(f"Loaded {len(patterns)} patterns from {moduleignore_path}")
+    
+    # 3. Add Makefile.py patterns
+    if extra_patterns:
+        all_patterns.extend(extra_patterns)
+        log.debug(f"Added {len(extra_patterns)} patterns from Makefile.py")
+    
+    # Compile with gitwildmatch semantics
+    if all_patterns:
+        spec = pathspec.PathSpec.from_lines('gitignore', all_patterns)
+        log.debug(f"Compiled {len(all_patterns)} total ignore patterns")
+    else:
+        spec = pathspec.PathSpec.from_lines('gitignore', [])
+    
+    return IgnoreSpec(spec)
+
+
+# Legacy API compatibility functions
+
+
+def readIgnoreFile(file=Path(preconts.MODULEIGNORE_FILE)):
+    """Legacy function for backward compatibility.
+    
+    Returns list of Path objects from ignore file (exact-match legacy behavior).
+    Prefer using read_ignore_spec() for new code.
+    """
     ignorelist = []
     try:
-        ignoreFile = open(str(file), 'r')
-        for line in ignoreFile:
-            ignorelist.append(Path(line.rstrip()))
+        with open(str(file), 'r', encoding='utf-8') as ignoreFile:
+            for line in ignoreFile:
+                line = line.rstrip()
+                if line and not line.lstrip().startswith('#'):
+                    ignorelist.append(Path(line))
     except:
         pass
     return ignorelist
 
 
-def writeIgnoreFile( ignoreList: list, file = Path(preconts.MODULEIGNORE_FILE)):
-
+def writeIgnoreFile(ignoreList: list, file=Path(preconts.MODULEIGNORE_FILE)):
+    """Legacy function for backward compatibility.
+    
+    Writes ignore patterns to file, merging with existing content.
+    """
     currList = readIgnoreFile(file)
 
     try:
-
-        ignoreFile = open(str(file), "w")
-
-        for item in ignoreList:
-            if not Path(item) in currList:
-                currList.append(item)
-        
-        ignores = list(map(str, currList))
-        ignores = map(lambda x: x + '\n', ignores)
-        ignoreFile.writelines(ignores)
-
+        with open(str(file), "w", encoding='utf-8') as ignoreFile:
+            for item in ignoreList:
+                if Path(item) not in currList:
+                    currList.append(item)
+            
+            ignores = list(map(str, currList))
+            ignores = [x + '\n' for x in ignores]
+            ignoreFile.writelines(ignores)
     except Exception as e:
         print(e)

--- a/src/pymakelib/prelib.py
+++ b/src/pymakelib/prelib.py
@@ -407,6 +407,11 @@ def read_Makefilepy_obj(workpath='') -> AbstractMake:
                 return getattr(mod, K.MK_F_GETCOMPILEROPTS)()
             def getLinkerOpts(self, **kwargs) -> dict:
                 return getattr(mod, K.MK_F_GETLINKEROPTS)()
+            def getTargetsScript(self, **kwargs) -> dict:
+                return getattr(mod, K.MK_F_GETTARGETSSCRIPT)()
+            def getPhonyTargets(self) -> dict:
+                fn = getattr(mod, K.MK_F_GETPHONYTARGETS, None)
+                return fn() if fn else {}
         projectInstance = bproject()
     return projectInstance
 

--- a/src/pymakelib/scripts/pymaketool
+++ b/src/pymakelib/scripts/pymaketool
@@ -104,10 +104,17 @@ if not goal:
 
 modules = []
 modulesPaths = []
-ignoreModuleList = []
 
 # Add project path to sys.path for users scripts
 sys.path.append(str(os.getcwd()))
+
+# Detect project root and config directory (for pymake/ layout)
+project_root = Path('.').resolve()
+try:
+    config_dir, layout_mode = plib.resolve_config_dir(project_root)
+except FileNotFoundError:
+    print("Not a pymaketool project")
+    sys.exit()
 
 projSettings, compilerOpts, compilerSettings = plib.read_Makefilepy()
 
@@ -119,7 +126,18 @@ globalSettings = {
 
 project.setSettings(globalSettings)
 
-ignoreModuleList = moduleignore.readIgnoreFile()
+# Get ignore configuration from Makefile.py if available
+projectInstance = plib.getProjectInstance()
+ignore_config = {}
+if projectInstance and hasattr(projectInstance, 'getIgnoreConfig'):
+    ignore_config = projectInstance.getIgnoreConfig()
+
+# Read and compile ignore patterns with gitignore-style semantics
+ignore_spec = moduleignore.read_ignore_spec(
+    project_root=project_root,
+    config_dir=config_dir,
+    makefile_config=ignore_config
+)
 
 #Execute GenHeaders
 headersPaths = list(Path('./').rglob('*[.|_]h.py'))
@@ -132,16 +150,28 @@ for gheader in headersPaths:
 modulesPaths = list(
     sorted(set(Path('./').rglob('*[.|_]mk.py')) | set(Path('./').rglob('mk.py')))
 )
+
+# Filter out ignored modules before loading (more efficient)
+if ignore_spec:
+    filtered_paths = []
+    for module_path in modulesPaths:
+        # Normalize to project-relative POSIX path for matching
+        try:
+            rel_path = module_path.relative_to(project_root)
+            posix_path = str(rel_path).replace('\\', '/')
+        except ValueError:
+            # Path outside project root, use as-is
+            posix_path = str(module_path).replace('\\', '/')
+        
+        if not ignore_spec.match_file(posix_path):
+            filtered_paths.append(module_path)
+    
+    modulesPaths = filtered_paths
+
 # Load modules
 for filename in modulesPaths:
     mod = plib.readModule(filename, copy.deepcopy(compilerOpts), goal)
     modules.extend(mod)
-
-for ex in ignoreModuleList:
-    for i, o in enumerate(modules):
-        if o.filename == ex:
-            del modules[i]
-            break
 
 # Write CSRC
 srcsfile = open('srcs.mk', 'w')

--- a/src/pymaketool/__init__.py
+++ b/src/pymaketool/__init__.py
@@ -135,28 +135,62 @@ def main():
 
     project.setSettings(globalSettings)
 
-    ignoreModuleList = moduleignore.readIgnoreFile()
+    # Get ignore configuration from Makefile.py if available
+    projectInstance = plib.getProjectInstance()
+    ignore_config = {}
+    if projectInstance and hasattr(projectInstance, 'getIgnoreConfig'):
+        ignore_config = projectInstance.getIgnoreConfig()
+    
+    # Read and compile ignore patterns with gitignore-style semantics
+    ignore_spec = moduleignore.read_ignore_spec(
+        project_root=project_root,
+        config_dir=config_dir,
+        makefile_config=ignore_config
+    )
 
     # Execute GenHeaders
-    headersPaths = list(Path("./").rglob("*[.|_]h.py"))
+    # Use os.walk(followlinks=True) so that symlinked directories (e.g.
+    # TARGET/ and wrapper/ in the pytest-qemu-pic32mk workspace) are scanned.
+    def _rglob_follow(pattern: str):
+        import fnmatch
+        results = []
+        for root, dirs, files in os.walk(".", followlinks=True):
+            for fname in files:
+                if fnmatch.fnmatch(fname, pattern):
+                    results.append(Path(root) / fname)
+        return results
+
+    headersPaths = _rglob_follow("*[.|_]h.py")
     for gheader in headersPaths:
         fileout = re.sub("[.|_]h.py", ".h", str(gheader))
         print(f"Generator: {gheader} > {fileout}")
         plib.readGenHeader(gheader)
 
     modulesPaths = sorted(
-        set(Path("./").rglob("*[.|_]mk.py")) | set(Path("./").rglob("mk.py"))
+        set(_rglob_follow("*[.|_]mk.py")) | set(_rglob_follow("mk.py"))
     )
+    
+    # Filter out ignored modules before loading (more efficient)
+    if ignore_spec:
+        filtered_paths = []
+        for module_path in modulesPaths:
+            # Normalize to project-relative POSIX path for matching
+            try:
+                rel_path = module_path.relative_to(project_root)
+                posix_path = str(rel_path).replace('\\', '/')
+            except ValueError:
+                # Path outside project root, use as-is
+                posix_path = str(module_path).replace('\\', '/')
+            
+            if not ignore_spec.match_file(posix_path):
+                filtered_paths.append(module_path)
+        
+        modulesPaths = filtered_paths
+    
     # Load modules
     for filename in modulesPaths:
         mod = plib.readModule(filename, copy.deepcopy(compilerOpts), goal, project_root=Path(".").resolve())
         modules.extend(mod)
-
-    for ex in ignoreModuleList:
-        for i, o in enumerate(modules):
-            if o.filename == ex:
-                del modules[i]
-                break
 
     # Write CSRC
     srcsfile = open(config_dir / K.SRCS_MK, "w")

--- a/tests/test_moduleignore.py
+++ b/tests/test_moduleignore.py
@@ -1,0 +1,313 @@
+"""Tests for moduleignore module with gitignore-style semantics."""
+
+import unittest
+import tempfile
+from pathlib import Path
+from pymakelib import moduleignore
+
+
+class TestIgnorePatternParsing(unittest.TestCase):
+    """Test pattern file parsing (comments, blanks, etc.)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_read_patterns_skips_blank_lines(self):
+        """Blank lines should be ignored."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('\n\napp_mk.py\n\n\ntest/\n')
+        
+        patterns = moduleignore._read_patterns_from_file(ignore_file)
+        self.assertEqual(2, len(patterns))
+        self.assertIn('app_mk.py', patterns)
+        self.assertIn('test/', patterns)
+
+    def test_read_patterns_skips_comments(self):
+        """Lines starting with # should be ignored."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('# Comment\napp_mk.py\n  # Indented comment\ntest/')
+        
+        patterns = moduleignore._read_patterns_from_file(ignore_file)
+        self.assertEqual(2, len(patterns))
+        self.assertIn('app_mk.py', patterns)
+        self.assertIn('test/', patterns)
+
+    def test_read_patterns_preserves_trailing_slash(self):
+        """Trailing slashes should be preserved for directory matching."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('build/\ntest/')
+        
+        patterns = moduleignore._read_patterns_from_file(ignore_file)
+        self.assertEqual(2, len(patterns))
+        self.assertIn('build/', patterns)
+        self.assertIn('test/', patterns)
+
+    def test_read_patterns_nonexistent_file_returns_empty(self):
+        """Non-existent file should return empty list."""
+        patterns = moduleignore._read_patterns_from_file(
+            self.project_root / 'nonexistent.txt'
+        )
+        self.assertEqual(0, len(patterns))
+
+
+class TestIgnoreSpecMatching(unittest.TestCase):
+    """Test gitignore-style pattern matching."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_exact_path_match(self):
+        """Exact paths should match."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('app_mk.py')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        self.assertTrue(spec.match_file('app_mk.py'))
+        self.assertFalse(spec.match_file('lib_mk.py'))
+
+    def test_wildcard_asterisk(self):
+        """Wildcard * should match multiple characters."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('test_*')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        self.assertTrue(spec.match_file('test_app_mk.py'))
+        self.assertTrue(spec.match_file('test_mk.py'))
+        self.assertFalse(spec.match_file('app_mk.py'))
+
+    def test_directory_pattern(self):
+        """Trailing slash should match directories and their contents."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('build/')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        self.assertTrue(spec.match_file('build/app_mk.py'))
+        self.assertTrue(spec.match_file('build/lib/test_mk.py'))
+        self.assertFalse(spec.match_file('src/build_mk.py'))
+
+    def test_recursive_wildcard(self):
+        """** should match any depth."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('**/test_*')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        self.assertTrue(spec.match_file('test_app_mk.py'))
+        self.assertTrue(spec.match_file('src/test_util_mk.py'))
+        self.assertTrue(spec.match_file('src/lib/test_helper_mk.py'))
+        self.assertFalse(spec.match_file('src/app_mk.py'))
+
+    def test_negation_pattern(self):
+        """! should negate a previous pattern."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('*.py\n!main.py')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        self.assertTrue(spec.match_file('test.py'))
+        self.assertFalse(spec.match_file('main.py'))
+
+    def test_empty_spec_matches_nothing(self):
+        """Empty ignore spec should match nothing."""
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        self.assertFalse(spec.match_file('app_mk.py'))
+        self.assertFalse(spec.match_file('test/lib_mk.py'))
+        # Empty spec should evaluate to False
+        self.assertFalse(bool(spec))
+
+
+class TestIgnoreFileLocation(unittest.TestCase):
+    """Test .moduleignore file location resolution."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_prefers_pymake_location(self):
+        """Should prefer pymake/.moduleignore over root."""
+        pymake_dir = self.project_root / 'pymake'
+        pymake_dir.mkdir()
+        
+        # Create both files with different content
+        (pymake_dir / '.moduleignore').write_text('from_pymake')
+        (self.project_root / '.moduleignore').write_text('from_root')
+        
+        moduleignore_path, _ = moduleignore._resolve_ignore_file_paths(
+            self.project_root, pymake_dir
+        )
+        
+        self.assertEqual(moduleignore_path, pymake_dir / '.moduleignore')
+
+    def test_fallback_to_root_location(self):
+        """Should fallback to root .moduleignore if pymake/ doesn't have it."""
+        pymake_dir = self.project_root / 'pymake'
+        pymake_dir.mkdir()
+        
+        (self.project_root / '.moduleignore').write_text('from_root')
+        
+        moduleignore_path, _ = moduleignore._resolve_ignore_file_paths(
+            self.project_root, pymake_dir
+        )
+        
+        self.assertEqual(moduleignore_path, self.project_root / '.moduleignore')
+
+    def test_no_moduleignore_returns_none(self):
+        """Should return None if no .moduleignore exists."""
+        moduleignore_path, _ = moduleignore._resolve_ignore_file_paths(
+            self.project_root, None
+        )
+        
+        self.assertIsNone(moduleignore_path)
+
+    def test_gitignore_resolved_at_root(self):
+        """Should find .gitignore at project root."""
+        (self.project_root / '.gitignore').write_text('*.o')
+        
+        _, gitignore_path = moduleignore._resolve_ignore_file_paths(
+            self.project_root, None
+        )
+        
+        self.assertEqual(gitignore_path, self.project_root / '.gitignore')
+
+
+class TestIgnoreSourceMerging(unittest.TestCase):
+    """Test merging patterns from multiple sources."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_merges_gitignore_and_moduleignore(self):
+        """Should merge patterns from both files."""
+        (self.project_root / '.gitignore').write_text('*.o\nbuild/')
+        (self.project_root / '.moduleignore').write_text('test_*')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        
+        # All patterns should be active
+        self.assertTrue(spec.match_file('main.o'))
+        self.assertTrue(spec.match_file('build/app_mk.py'))
+        self.assertTrue(spec.match_file('test_mk.py'))
+
+    def test_moduleignore_can_override_gitignore(self):
+        """Moduleignore patterns (loaded later) can negate gitignore."""
+        (self.project_root / '.gitignore').write_text('*.py')
+        (self.project_root / '.moduleignore').write_text('!*_mk.py')
+        
+        spec = moduleignore.read_ignore_spec(self.project_root)
+        
+        # Regular .py ignored, but _mk.py allowed
+        self.assertTrue(spec.match_file('test.py'))
+        self.assertFalse(spec.match_file('app_mk.py'))
+
+    def test_makefile_config_adds_extra_patterns(self):
+        """Makefile.py ignore_list should add patterns."""
+        (self.project_root / '.moduleignore').write_text('test_*')
+        
+        config = {'ignore_list': ['vendor/', 'third_party/']}
+        spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            makefile_config=config
+        )
+        
+        self.assertTrue(spec.match_file('test_mk.py'))
+        self.assertTrue(spec.match_file('vendor/lib_mk.py'))
+        self.assertTrue(spec.match_file('third_party/ext_mk.py'))
+
+    def test_use_gitignore_false_disables_gitignore(self):
+        """use_gitignore=False should skip .gitignore."""
+        (self.project_root / '.gitignore').write_text('*.o')
+        (self.project_root / '.moduleignore').write_text('test_*')
+        
+        config = {'use_gitignore': False}
+        spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            makefile_config=config
+        )
+        
+        # .gitignore patterns should not be active
+        self.assertFalse(spec.match_file('main.o'))
+        # .moduleignore patterns should still work
+        self.assertTrue(spec.match_file('test_mk.py'))
+
+
+class TestPathNormalization(unittest.TestCase):
+    """Test path normalization for consistent matching."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_normalize_absolute_path(self):
+        """Should normalize absolute paths to project-relative."""
+        abs_path = self.project_root / 'src' / 'app_mk.py'
+        normalized = moduleignore._normalize_path(abs_path, self.project_root)
+        
+        self.assertEqual('src/app_mk.py', normalized)
+
+    def test_normalize_relative_path(self):
+        """Should preserve relative paths with POSIX separators."""
+        rel_path = Path('src/app_mk.py')
+        normalized = moduleignore._normalize_path(rel_path, self.project_root)
+        
+        self.assertEqual('src/app_mk.py', normalized)
+
+    def test_normalize_windows_separators(self):
+        """Should convert backslashes to forward slashes."""
+        # Create a path with backslashes
+        win_path = Path('src\\app_mk.py')
+        normalized = moduleignore._normalize_path(win_path, self.project_root)
+        
+        # Should use forward slashes
+        self.assertIn('/', normalized)
+        self.assertNotIn('\\', normalized)
+
+
+class TestLegacyCompatibility(unittest.TestCase):
+    """Test backward compatibility with old readIgnoreFile API."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_readIgnoreFile_returns_path_list(self):
+        """Legacy readIgnoreFile should return list of Path objects."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('app_mk.py\ntest/lib_mk.py')
+        
+        result = moduleignore.readIgnoreFile(ignore_file)
+        
+        self.assertEqual(2, len(result))
+        self.assertIsInstance(result[0], Path)
+        self.assertEqual('app_mk.py', str(result[0]))
+
+    def test_readIgnoreFile_skips_comments_and_blanks(self):
+        """Legacy API should also skip comments and blanks."""
+        ignore_file = self.project_root / '.moduleignore'
+        ignore_file.write_text('# Comment\n\napp_mk.py\n  # Another comment\ntest/')
+        
+        result = moduleignore.readIgnoreFile(ignore_file)
+        
+        self.assertEqual(2, len(result))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_moduleignore_integration.py
+++ b/tests/test_moduleignore_integration.py
@@ -1,0 +1,224 @@
+"""Integration tests for module discovery with ignore functionality."""
+
+import unittest
+import tempfile
+import shutil
+from pathlib import Path
+import sys
+
+
+class TestDiscoveryWithIgnore(unittest.TestCase):
+    """Integration test for module discovery filtering via ignore patterns."""
+
+    def setUp(self):
+        """Create a temporary test project."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+        
+        # Add project root to sys.path
+        sys.path.insert(0, str(self.project_root))
+
+    def tearDown(self):
+        """Clean up temporary project."""
+        # Remove from sys.path
+        if str(self.project_root) in sys.path:
+            sys.path.remove(str(self.project_root))
+        
+        # Clean up global ProjectInstance to avoid polluting other tests
+        import pymakelib
+        pymakelib.ProjectInstance = None
+        
+        self.temp_dir.cleanup()
+
+    def _create_minimal_makefile_py(self, ignore_config=None):
+        """Create a minimal Makefile.py for testing."""
+        pymake_dir = self.project_root / 'pymake'
+        pymake_dir.mkdir(exist_ok=True)
+        
+        makefile_content = '''
+from pymakelib import ProjectConfig, Makeclass, MKVARS, Target
+from pymakelib.toolchain import get_gcc_linux
+
+@Makeclass
+class Build(ProjectConfig):
+    name = 'testproject'
+    compiler_set = get_gcc_linux()
+'''
+        
+        if ignore_config:
+            if 'use_gitignore' in ignore_config:
+                makefile_content += f"\n    use_gitignore = {ignore_config['use_gitignore']}"
+            if 'ignore_list' in ignore_config:
+                patterns_str = str(ignore_config['ignore_list'])
+                makefile_content += f"\n    ignore_list = {patterns_str}"
+        
+        makefile_content += '''
+    
+    def targets(self):
+        return {
+            'TARGET': Target(
+                file='build/testproject',
+                script=[MKVARS.LD, '-o', '$@', MKVARS.OBJECTS],
+                logkey='OUT'
+            )
+        }
+'''
+        
+        (pymake_dir / 'Makefile.py').write_text(makefile_content)
+
+    def _create_module_file(self, path):
+        """Create a minimal module file."""
+        module_path = self.project_root / path
+        module_path.parent.mkdir(parents=True, exist_ok=True)
+        module_path.write_text('from pm import mk\nmk()\n')
+
+    def test_discovery_with_moduleignore_wildcard(self):
+        """Test that wildcard patterns in .moduleignore filter modules."""
+        # Create Makefile.py
+        self._create_minimal_makefile_py()
+        
+        # Create modules
+        self._create_module_file('app/mk.py')
+        self._create_module_file('test_app_mk.py')
+        self._create_module_file('test_lib_mk.py')
+        
+        # Create .moduleignore with wildcard
+        (self.project_root / 'pymake' / '.moduleignore').write_text('test_*')
+        
+        # Import and run discovery
+        from pymakelib import moduleignore, prelib
+        
+        # Resolve config
+        config_dir, _ = prelib.resolve_config_dir(self.project_root)
+        
+        # Read ignore spec
+        ignore_spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            config_dir=config_dir
+        )
+        
+        # Test patterns
+        self.assertTrue(ignore_spec.match_file('test_app_mk.py'))
+        self.assertTrue(ignore_spec.match_file('test_lib_mk.py'))
+        self.assertFalse(ignore_spec.match_file('app/mk.py'))
+
+    def test_discovery_with_gitignore_by_default(self):
+        """Test that .gitignore is read by default."""
+        # Create Makefile.py
+        self._create_minimal_makefile_py()
+        
+        # Create .gitignore
+        (self.project_root / '.gitignore').write_text('build/\n*.tmp')
+        
+        # Import and run discovery
+        from pymakelib import moduleignore, prelib
+        
+        config_dir, _ = prelib.resolve_config_dir(self.project_root)
+        
+        ignore_spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            config_dir=config_dir
+        )
+        
+        # Test gitignore patterns are active
+        self.assertTrue(ignore_spec.match_file('build/app_mk.py'))
+        self.assertTrue(ignore_spec.match_file('test.tmp'))
+
+    def test_discovery_can_disable_gitignore(self):
+        """Test that use_gitignore=False disables .gitignore."""
+        # Create Makefile.py with use_gitignore=False
+        self._create_minimal_makefile_py({'use_gitignore': False})
+        
+        # Create .gitignore
+        (self.project_root / '.gitignore').write_text('build/')
+        
+        # Import and run discovery
+        from pymakelib import moduleignore, prelib
+        
+        config_dir, _ = prelib.resolve_config_dir(self.project_root)
+        
+        # Get project instance to read config
+        prelib.read_Makefilepy(config_dir=config_dir)
+        projectInstance = prelib.getProjectInstance()
+        ignore_config = projectInstance.getIgnoreConfig()
+        
+        ignore_spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            config_dir=config_dir,
+            makefile_config=ignore_config
+        )
+        
+        # .gitignore patterns should not be active
+        self.assertFalse(ignore_spec.match_file('build/app_mk.py'))
+
+    def test_discovery_with_makefile_ignore_list(self):
+        """Test that ignore_list in Makefile.py adds patterns."""
+        # Create Makefile.py with ignore_list
+        self._create_minimal_makefile_py({
+            'ignore_list': ['vendor/', 'third_party/']
+        })
+        
+        # Import and run discovery
+        from pymakelib import moduleignore, prelib
+        
+        config_dir, _ = prelib.resolve_config_dir(self.project_root)
+        
+        prelib.read_Makefilepy(config_dir=config_dir)
+        projectInstance = prelib.getProjectInstance()
+        ignore_config = projectInstance.getIgnoreConfig()
+        
+        ignore_spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            config_dir=config_dir,
+            makefile_config=ignore_config
+        )
+        
+        # Makefile.py patterns should be active
+        self.assertTrue(ignore_spec.match_file('vendor/ext_mk.py'))
+        self.assertTrue(ignore_spec.match_file('third_party/lib_mk.py'))
+
+    def test_discovery_with_directory_ignore(self):
+        """Test that directory patterns ignore subdirectories."""
+        self._create_minimal_makefile_py()
+        
+        # Create .moduleignore with directory pattern
+        (self.project_root / 'pymake' / '.moduleignore').write_text('tests/')
+        
+        from pymakelib import moduleignore, prelib
+        
+        config_dir, _ = prelib.resolve_config_dir(self.project_root)
+        
+        ignore_spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            config_dir=config_dir
+        )
+        
+        # Should match anything under tests/
+        self.assertTrue(ignore_spec.match_file('tests/app_mk.py'))
+        self.assertTrue(ignore_spec.match_file('tests/unit/lib_mk.py'))
+        self.assertFalse(ignore_spec.match_file('src/test_app_mk.py'))
+
+    def test_moduleignore_in_pymake_preferred_over_root(self):
+        """Test that pymake/.moduleignore is preferred over root."""
+        self._create_minimal_makefile_py()
+        
+        # Create both ignore files with different patterns
+        (self.project_root / '.moduleignore').write_text('pattern_from_root')
+        (self.project_root / 'pymake' / '.moduleignore').write_text('pattern_from_pymake')
+        
+        from pymakelib import moduleignore, prelib
+        
+        config_dir, _ = prelib.resolve_config_dir(self.project_root)
+        
+        ignore_spec = moduleignore.read_ignore_spec(
+            self.project_root,
+            config_dir=config_dir
+        )
+        
+        # Should use pymake/.moduleignore pattern
+        self.assertTrue(ignore_spec.match_file('pattern_from_pymake'))
+        self.assertFalse(ignore_spec.match_file('pattern_from_root'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Replace line-by-line path exclusion with full gitwildmatch semantics via pathspec. Reads .gitignore by default and .moduleignore for custom rules. AbstractMake gains getIgnoreConfig(); ProjectConfig gains use_gitignore and ignore_list fields. Modules filtered before loading for efficiency. Fix symlinked-directory path resolution in module.py.